### PR TITLE
Add support for WPA2 to the post-install, and rebrand the footer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # PentestBox
-This repository contains tools to create a 2GB SD card image based upon latest arch sources including all dependencies 
+This repository contains tools to create a 2GB SD card image based upon the latest Arch Linux sources including all the dependencies 
 for PentestBox. PentestBox is a fork of the Piratebox project, intended for use by penetration testers and designed for 
 security.
 
-# Build the Image
+The default network the device creates when it boots is:
+SSID: PentestBox Network
+PSK: PENTESTBOX
+
+The default credentials to log in to the device, which will have a default IP of 192.168.77.1, are:
+Username: alarm
+Password: alarm
+
+You will be prompted to change all of these defaults by the post-installation script.
+
+# Building the Image
 Run ./build.sh.  The build script will ask some simple questions.  It will then install required dependencies and build the PentestBox image automagically.  
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ for PentestBox. PentestBox is a fork of the Piratebox project, intended for use 
 security.
 
 The default network the device creates when it boots is:
-SSID: PentestBox Network
-PSK: PENTESTBOX
-
+```
+SSID: PentestBox Network    
+PSK: PENTESTBOX    
+```
 The default credentials to log in to the device, which will have a default IP of 192.168.77.1, are:
-Username: alarm
-Password: alarm
-
+```
+Username: alarm    
+Password: alarm    
+```
 You will be prompted to change all of these defaults by the post-installation script.
 
 # Building the Image

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 ### For next release
 
 * [ ] Change to exFAT for the USB filesystem
+* [ ] Make the build script work across distributions.
 
 ### Maybe later
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,17 +2,15 @@
 
 ### Backlog
 
-* [ ] Add shout outs for the people involved in testing (waiting for TheExpertNoob)
-
 ### For next release
 
-* [ ] Make sure the Makefile is compatible to "older" systems, do not use fancy options that are not supported through all versions of wget and similar
+* [ ] Change to exFAT for the USB filesystem
 
 ### Maybe later
 
 * [ ] rename hostname to something cool
-* [ ] swap the alarm user with something related to PirateBox
-* [ ] Add information about raspiconfig and disk resize to MOTD
+* [ ] swap the alarm user with something related to PentestBox
+* [ ] Add an Armitage/Metasploit server
 
 ### Done
 Just for reference until they have been noted in a Changelog.

--- a/build.sh
+++ b/build.sh
@@ -20,8 +20,8 @@ fi
 
 
 dialog --backtitle "PentestBox Build Script" --title "Welcome!" \
---msgbox "Welcome to the PentestBox Build Script. Please ensure that you have made any changes you wish to make in the ptb-config folder before continuing with this script." \
-10 50
+--msgbox "Welcome to the PentestBox Build Script. \nPlease ensure that you have made any extra changes you wish to make \nin the ptb-config folder before continuing with this script." \
+10 45
 
 #Dialog vars
 DIALOG_CANCEL=1

--- a/chroot/post_install.sh
+++ b/chroot/post_install.sh
@@ -53,9 +53,9 @@ bash /opt/piratebox/bin/board-autoconf.sh
 echo 1
 echo XXX; echo 5; echo "Setting up fake time..."; echo XXX
 /opt/piratebox/bin/timesave.sh /opt/piratebox/conf/piratebox.conf install
-timedatectl set-ntp false
+timedatectl set-ntp false > /dev/null
 date -s "20170523 1742"
-systemctl enable timesave
+systemctl enable timesave > /dev/null
 
 echo XXX; echo 25; echo "Configuring wireless..."; echo XXX
 case $WIFI in

--- a/chroot/post_install.sh
+++ b/chroot/post_install.sh
@@ -47,6 +47,28 @@ WIFI=$(
 exec 4>&-
 echo $WIFI
 
+exec 4>&1
+SSID=$(
+    dialog \
+    --backtitle "PentestBox Post-Installation Script" \
+    --title "Choose SSID" \
+    --inputbox "Please choose an SSID for the PentestBox's network." \
+    8 50 "PentestBox Network" 2>&1 1>&4
+);
+exec 4>&-
+echo $SSID
+
+exec 4>&1
+PSK=$(
+    dialog \
+    --backtitle "PentestBox Post-Installation Script" \
+    --title "Enter PSK" \
+    --insecure --passwordbox "Please enter a passphrase for the PentestBox's network." \
+    8 55
+);
+exec 4>&-
+echo $PSK
+
 bash /opt/piratebox/bin/board-autoconf.sh
 
 (
@@ -57,7 +79,7 @@ timedatectl set-ntp false > /dev/null
 date -s "20170523 1742"
 systemctl enable timesave > /dev/null
 
-echo XXX; echo 25; echo "Configuring wireless..."; echo XXX
+echo XXX; echo 10; echo "Configuring WiFi"; echo XXX
 case $WIFI in
 1)
     echo "wlan0" > /boot/wifi_card.conf
@@ -66,6 +88,10 @@ case $WIFI in
     echo "wlan1" > /boot/wifi_card.conf
     ;;
 esac
+
+echo XXX; echo 25; echo "Setting SSID/PSK..."; echo XXX
+sed -i "s|PentestBox Network|$SSID|g" /opt/piratebox/hostapd.conf
+sed -i "s|PENTESTBOX|$PSK|g" /opt/piratebox/hostapd.conf
 
 echo XXX; echo 50; echo "Setting up storage..."; echo XXX
 case $STORAGE in

--- a/piratebox-ws/piratebox/piratebox/conf/hostapd.conf
+++ b/piratebox-ws/piratebox/piratebox/conf/hostapd.conf
@@ -16,8 +16,8 @@ hw_mode=g
 ap_isolate=1
 
 # Uncomment the following lines to enable WPA
-#wpa=2
-#wpa_key_mgmt=WPA-PSK
-#wpa_pairwise=TKIP CCMP
-#rsn_pairwise=CCMP
-#wpa_passphrase=Somepassphrase
+wpa=2
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=TKIP CCMP
+rsn_pairwise=CCMP
+wpa_passphrase=PENTESTBOX

--- a/piratebox-ws/piratebox/piratebox/src/kareha_img_config.pl
+++ b/piratebox-ws/piratebox/piratebox/src/kareha_img_config.pl
@@ -12,7 +12,7 @@
 
 # Page look
 use constant TITLE => 'PentestBox board';	# Name of this image board
-use constant SHOWTITLETXT => 1;				# Show TITLE at top (1: yes  0: no)
+use constant SHOWTITLETXT => 0;				# Show TITLE at top (1: yes  0: no)
 use constant SHOWTITLEIMG => 1;				# Show image at top (0: no, 1: single, 2: rotating)
 use constant TITLEIMG => '/content/img/piratebox-logo-small.png';			# Title image (point to a script file if rotating)
 #use constant THREADS_DISPLAYED => 10;			# Number of threads on the front page

--- a/piratebox-ws/piratebox/piratebox/www_content/locales/data.en.properties
+++ b/piratebox-ws/piratebox/piratebox/www_content/locales/data.en.properties
@@ -6,11 +6,11 @@ navbarHome = Home
 navbarForum = Forum
 navbarFiles = Files
 navbarAbout = About
-logoIMG.alt = PirateBox
-logoIMG.title = PirateBox - Share Freely
+logoIMG.alt = PentestBox
+logoIMG.title = PentestBox Web Interface
 
-welcomeWelcome = Welcome
-welcomeDescription.innerHTML = Now, first of all, there is nothing illegal or scary going on here. This is a social place where you can chat and share files with people around you, <strong>anonymously</strong>! This is an off-line network, specially designed and developed for file-sharing and chat services. Staying off the grid is a precaution to maintain your full anonymity. Please have fun, chat with people, and feel free to share any files you may like.
+welcomeWelcome = Welcome!
+welcomeDescription.innerHTML = Welcome to the web interface of the PentestBox.
 welcomeThanksButton.value = Thanks
 sidebarUpload = Go to Upload ->
 sidebarIframeNotSupported = Your browser does not support iframes.. If you want to upload something, follow this
@@ -34,6 +34,6 @@ mainShoutboxRed = Red
 
 footerBackToTop = Back to top
 footerAbout = About
-footerInspired = Inspired by pirate radio and the free culture movement, PirateBox is a self-contained mobile collaboration and file sharing device. PirateBox utilizes Free, Libre and Open Source software (FLOSS) to create mobile wireless file sharing networks where users can anonymously share images, video, audio, documents, and other digital content.
-footerFilesTopSafety = PirateBox is designed to be safe and secure. No logins are required and no user data is logged. The system is purposely not connected to the Internet in order to prevent tracking and preserve user privacy.
-footerLicenceMain = PirateBox is licensed under GPLv3.
+footerInspired = PentestBox is designed for use by penetration testers in the field, as a shared drive for collaboration.
+footerFilesTopSafety = PentestBox is designed to be safe and secure. No logins are required and no user data is logged. The system is purposely not connected to the Internet in order to prevent tracking and preserve user privacy.
+footerLicenceMain = PentestBox is forked from the PirateBox project, licensed under GPLv3.


### PR DESCRIPTION
- The post-install script now asks for an SSID and passphrase, and should set them appropriately in hostapd.conf with sed.  This also means that the device boots in WPA2 mode.  The default passphrase is in README.md.

- The footer of the main page has been rebranded.

- The imageboard config has been modified so that it no longer displays the text title, and should just show our image.

- The post-install script should no longer be covered up by the systemd messages during the final config.

- README.md has been edited.